### PR TITLE
HomeApp: Switch from AndroidViewModel(application) to ViewModel()

### DIFF
--- a/app/src/main/java/io/budge/homeapp/ui/fragments/StepOneFragment.kt
+++ b/app/src/main/java/io/budge/homeapp/ui/fragments/StepOneFragment.kt
@@ -5,7 +5,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.ViewModelProvider
+import androidx.fragment.app.viewModels
 import io.budge.homeapp.databinding.FragmentStepOneBinding
 import io.budge.homeapp.ui.OnboardingViewModel
 import io.budge.homeapp.ui.activities.OnboardingActivity
@@ -14,7 +14,7 @@ import io.budge.homeapp.util.Logger
 class StepOneFragment : Fragment() {
     private var _binding: FragmentStepOneBinding? = null
     private val binding get() = _binding!!
-
+    private val viewModel: OnboardingViewModel by viewModels({ requireActivity() })
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?
     ): View {
@@ -26,8 +26,7 @@ class StepOneFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         Logger.v(TAG, "onViewCreated")
         super.onViewCreated(view, savedInstanceState)
-        val viewModel = ViewModelProvider(requireActivity())[OnboardingViewModel::class.java]
-        viewModel.currentStep = 1
+        viewModel.updateStep(requireContext(), 1)
         binding.buttonContinue.setOnClickListener {
             Logger.v(TAG, "Continue button clicked")
             (activity as? OnboardingActivity)?.goToNextStep()

--- a/app/src/main/java/io/budge/homeapp/ui/fragments/StepThreeFragment.kt
+++ b/app/src/main/java/io/budge/homeapp/ui/fragments/StepThreeFragment.kt
@@ -5,7 +5,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.ViewModelProvider
+import androidx.fragment.app.viewModels
 import io.budge.homeapp.databinding.FragmentStepThreeBinding
 import io.budge.homeapp.ui.OnboardingViewModel
 import io.budge.homeapp.util.Logger
@@ -14,7 +14,7 @@ class StepThreeFragment : Fragment() {
 
     private var _binding: FragmentStepThreeBinding? = null
     private val binding get() = _binding!!
-
+    private val viewModel: OnboardingViewModel by viewModels({ requireActivity() })
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?
     ): View {
@@ -33,8 +33,7 @@ class StepThreeFragment : Fragment() {
 
     private fun finishOnboarding() {
         Logger.v(TAG, "Continue clicked, finishing activity")
-        val viewModel = ViewModelProvider(requireActivity())[OnboardingViewModel::class.java]
-        viewModel.markComplete()
+        viewModel.markComplete(requireContext())
         activity?.finish()
     }
 

--- a/app/src/main/java/io/budge/homeapp/ui/fragments/StepTwoFragment.kt
+++ b/app/src/main/java/io/budge/homeapp/ui/fragments/StepTwoFragment.kt
@@ -17,7 +17,6 @@ class StepTwoFragment : Fragment() {
     private var _binding: FragmentStepTwoBinding? = null
     private val binding get() = _binding!!
 
-
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?
     ): View {
@@ -29,6 +28,7 @@ class StepTwoFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         Logger.v(TAG, "onViewCreated")
         super.onViewCreated(view, savedInstanceState)
+        Prefs.resetLaunchedFromStepTwo(requireContext())
         binding.buttonContinue.setOnClickListener {
             Logger.v(TAG, "Continue button clicked")
             launchHomeSettings()
@@ -38,6 +38,7 @@ class StepTwoFragment : Fragment() {
     override fun onResume() {
         super.onResume()
         Logger.v(TAG, "onResume")
+        Prefs.resetLaunchedFromStepTwo(requireContext())
         if (LauncherUtils.isAppDefaultLauncher(requireContext())) {
             Logger.v(TAG, "App is default launcher, go to step 3")
             (activity as? OnboardingActivity)?.goToNextStep()


### PR DESCRIPTION
Switch from AndroidViewModel(application) to ViewModel() for cleaner code and safety